### PR TITLE
Add cmake to AFL++ dependencies (apt)

### DIFF
--- a/Exercise 1/Readme.md
+++ b/Exercise 1/Readme.md
@@ -98,8 +98,8 @@ You can install everything in two ways:
   ```
   sudo apt-get update
   sudo apt-get install -y build-essential python3-dev automake git flex bison libglib2.0-dev libpixman-1-dev python3-setuptools
-  sudo apt-get install -y lld-11 llvm-11 llvm-11-dev clang-11 || sudo apt-get install -y lld llvm llvm-dev clang 
-  sudo apt-get install -y gcc-$(gcc --version|head -n1|sed 's/.* //'|sed 's/\..*//')-plugin-dev libstdc++-$(gcc --version|head -n1|sed 's/.* //'|sed 's/\..*//')-dev
+  sudo apt-get install -y lld-11 llvm-11 llvm-11-dev clang-11 || sudo apt-get install -y lld llvm llvm-dev clang
+  sudo apt-get install -y gcc-$(gcc --version|head -n1|sed 's/.* //'|sed 's/\..*//')-plugin-dev libstdc++-$(gcc --version|head -n1|sed 's/.* //'|sed 's/\..*//')-dev cmake
   ```
 
   Checkout and build AFL++


### PR DESCRIPTION
`make distrib` will fail if cmake is not installed.