### PR TITLE
fix(ex5): update libxml2 download link

### DIFF
--- a/Exercise 5/Readme.md
+++ b/Exercise 5/Readme.md
@@ -105,7 +105,7 @@ mkdir Fuzzing_libxml2 && cd Fuzzing_libxml2
 
 Download and uncompress libxml2-2.9.4.tar.gz
 ```
-wget http://xmlsoft.org/download/libxml2-2.9.4.tar.gz
+wget http://xmlsoft.org/sources/libxml2-2.9.4.tar.gz
 tar xvf libxml2-2.9.4.tar.gz && cd libxml2-2.9.4/
 ```
 


### PR DESCRIPTION
The path changed from `/download` to `/sources`.

``` bash
$ wget http://xmlsoft.org/download/libxml2-2.9.4.tar.gz
--2025-08-17 10:20:11--  http://xmlsoft.org/download/libxml2-2.9.4.tar.gz
Resolving xmlsoft.org (xmlsoft.org)... 149.202.84.84
Connecting to xmlsoft.org (xmlsoft.org)|149.202.84.84|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2025-08-17 10:20:11 ERROR 404: Not Found.

$ wget http://xmlsoft.org/sources/libxml2-2.9.4.tar.gz
--2025-08-17 10:20:46--  http://xmlsoft.org/sources/libxml2-2.9.4.tar.gz
Resolving xmlsoft.org (xmlsoft.org)... 149.202.84.84
Connecting to xmlsoft.org (xmlsoft.org)|149.202.84.84|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 5374830 (5.1M) [application/x-gzip]
Saving to: ‘libxml2-2.9.4.tar.gz’

libxml2-2.9.4.tar.gz            100%[======================================================>]   5.12M  4.83MB/s    in 1.1s

2025-08-17 10:20:48 (4.83 MB/s) - ‘libxml2-2.9.4.tar.gz’ saved [5374830/5374830]
```
